### PR TITLE
fix: 修复错误的 `Sort clients below channels` 翻译

### DIFF
--- a/src/lagos_zh.ts
+++ b/src/lagos_zh.ts
@@ -13919,7 +13919,7 @@ Once used, the privilege key will become invalid.</source>
     </message>
     <message>
         <source>Sort clients below channels</source>
-        <translation>排序频道中的用户</translation>
+        <translation>将用户排列于频道下方</translation>
     </message>
     <message>
         <source>Display country flag on clients</source>


### PR DESCRIPTION
默认情况在用户和子频道同级时，用户被排列在子频道上方
开启此开关会在父频道中，使用户排序在子频道下方